### PR TITLE
feat(api-v2): add GET /v2/slots/all-of-day to aggregate daily slots

### DIFF
--- a/apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/slots.controller.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/slots.controller.ts
@@ -32,6 +32,7 @@ import {
 import { plainToClass } from "class-transformer";
 
 import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import { SlotFormat } from "@calcom/platform-enums";
 import {
   GetSlotsInput_2024_09_04,
   GetSlotsInputPipe,
@@ -248,6 +249,37 @@ export class SlotsController_2024_09_04 {
     return {
       data: slots,
       status: SUCCESS_STATUS,
+    };
+  }
+
+  @Get("/all-of-day")
+  @ApiOperation({
+    summary: "Get all available slots for all event types on a given day",
+    description:
+      "Aggregates available slots across all non-archived, non-hidden event types for the specified date.",
+  })
+  @ApiQuery({ name: "date", required: true, example: "2050-09-05" })
+  @ApiQuery({
+    name: "timeZone",
+    required: false,
+    description: "Time zone for slot formatting. Defaults to UTC.",
+    example: "Europe/London",
+  })
+  @ApiQuery({
+    name: "format",
+    required: false,
+    description: "Format of slot times in response. Use 'range' to get start and end times.",
+    example: "range",
+  })
+  async getAllSlotsForDay(
+    @Query("date") date: string,
+    @Query("timeZone") timeZone?: string,
+    @Query("format") format?: SlotFormat
+  ): Promise<ApiResponse<unknown>> {
+    const data = await this.slotsService.getAllSlotsForDay({ date, timeZone, format });
+    return {
+      status: SUCCESS_STATUS,
+      data,
     };
   }
 

--- a/apps/api/v2/src/modules/slots/slots-2024-09-04/services/slots.service.spec.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-09-04/services/slots.service.spec.ts
@@ -2,6 +2,7 @@ import { EventTypesRepository_2024_06_14 } from "@/ee/event-types/event-types_20
 import { AvailableSlotsService } from "@/lib/services/available-slots.service";
 import { MembershipsRepository } from "@/modules/memberships/memberships.repository";
 import { MembershipsService } from "@/modules/memberships/services/memberships.service";
+import { PrismaReadService } from "@/modules/prisma/prisma-read.service";
 import { SlotsInputService_2024_09_04 } from "@/modules/slots/slots-2024-09-04/services/slots-input.service";
 import { SlotsOutputService_2024_09_04 } from "@/modules/slots/slots-2024-09-04/services/slots-output.service";
 import { SlotsRepository_2024_09_04 } from "@/modules/slots/slots-2024-09-04/slots.repository";
@@ -21,6 +22,16 @@ describe("SlotsService_2024_09_04", () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SlotsService_2024_09_04,
+        {
+          provide: PrismaReadService,
+          useValue: {
+            prisma: {
+              eventType: {
+                findMany: jest.fn().mockResolvedValue([]),
+              },
+            },
+          },
+        },
         {
           provide: SlotsInputService_2024_09_04,
           useValue: {
@@ -146,7 +157,11 @@ describe("SlotsService_2024_09_04", () => {
         ...inputQuery,
       });
 
-      const { start: _1, end: _2, type: _3, ...queryWithoutStartEndAndType } = sharedTestData.baseInputQuery;
+      const queryWithoutStartEndAndType = Object.fromEntries(
+        Object.entries(sharedTestData.baseInputQuery).filter(
+          ([key]) => !["start", "end", "type"].includes(key)
+        )
+      );
 
       expect(availableSlotsService.getAvailableSlots).toHaveBeenCalledWith({
         input: {

--- a/apps/api/v2/src/modules/slots/slots-2024-09-04/services/slots.service.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-09-04/services/slots.service.ts
@@ -2,6 +2,7 @@ import { EventTypesRepository_2024_06_14 } from "@/ee/event-types/event-types_20
 import { AvailableSlotsService } from "@/lib/services/available-slots.service";
 import { MembershipsRepository } from "@/modules/memberships/memberships.repository";
 import { MembershipsService } from "@/modules/memberships/services/memberships.service";
+import { PrismaReadService } from "@/modules/prisma/prisma-read.service";
 import { TimeSlots } from "@/modules/slots/slots-2024-04-15/services/slots-output.service";
 import {
   SlotsInputService_2024_09_04,
@@ -49,7 +50,8 @@ export class SlotsService_2024_09_04 {
     private readonly membershipsService: MembershipsService,
     private readonly membershipsRepository: MembershipsRepository,
     private readonly teamsRepository: TeamsRepository,
-    private readonly availableSlotsService: AvailableSlotsService
+    private readonly availableSlotsService: AvailableSlotsService,
+    private readonly dbRead: PrismaReadService
   ) {}
 
   private async fetchAndFormatSlots(queryTransformed: InternalSlotsQuery, format?: SlotFormat) {
@@ -88,6 +90,79 @@ export class SlotsService_2024_09_04 {
   async getAvailableSlotsWithRouting(query: GetSlotsInputWithRouting_2024_09_04) {
     const queryTransformed = await this.slotsInputService.transformRoutingGetSlotsQuery(query);
     return this.fetchAndFormatSlots(queryTransformed, query.format);
+  }
+
+  async getAllSlotsForDay(input: { date: string; timeZone?: string; format?: SlotFormat }) {
+    const { date, timeZone, format } = input;
+    const start = DateTime.fromISO(date, { zone: "utc" }).startOf("day");
+    const end = DateTime.fromISO(date, { zone: "utc" }).endOf("day");
+
+    if (!start.isValid || !end.isValid) {
+      throw new BadRequestException("Invalid date. Expected ISO 8601 like 2050-09-05");
+    }
+
+    const eventTypes = await this.dbRead.prisma.eventType.findMany({
+      where: {
+        // Skip hidden event types to avoid noise
+        hidden: { equals: false },
+        // Only individual event types (owned by a user, not a team)
+        userId: { not: null },
+        teamId: null,
+      },
+      select: {
+        id: true,
+        slug: true,
+        userId: true,
+        teamId: true,
+      },
+    });
+
+    const startIso = start.toISO();
+    const endIso = end.toISO();
+
+    const results = await Promise.all(
+      eventTypes.map(async (et) => {
+        const internalQuery: InternalGetSlotsQuery = {
+          isTeamEvent: !!et.teamId,
+          startTime: startIso!,
+          endTime: endIso!,
+          duration: undefined,
+          eventTypeId: et.id,
+          eventTypeSlug: et.slug,
+          usernameList: [],
+          timeZone,
+          orgSlug: null,
+          rescheduleUid: null,
+        };
+
+        try {
+          const formatted = await this.fetchAndFormatSlots(internalQuery, format);
+          // The formatter returns a map keyed by dates in the requested TZ.
+          // Keep only the requested date key if present.
+          const formattedMap = formatted as Record<string, unknown[]>;
+          const onlyRequested = formattedMap && formattedMap[date] ? { [date]: formattedMap[date] } : {};
+
+          return {
+            eventTypeId: et.id,
+            eventTypeSlug: et.slug,
+            ownerUserId: et.userId ?? null,
+            ownerTeamId: et.teamId ?? null,
+            slotsByDate: onlyRequested,
+          };
+        } catch {
+          // Swallow per-event type errors to not fail the whole aggregation
+          return {
+            eventTypeId: et.id,
+            eventTypeSlug: et.slug,
+            ownerUserId: et.userId ?? null,
+            ownerTeamId: et.teamId ?? null,
+            slotsByDate: {},
+          };
+        }
+      })
+    );
+
+    return results;
   }
 
   async reserveSlot(input: ReserveSlotInput_2024_09_04, authUserId?: number) {

--- a/docs/api-reference/v2/openapi.json
+++ b/docs/api-reference/v2/openapi.json
@@ -11867,6 +11867,67 @@
         "tags": ["Slots"]
       }
     },
+    "/v2/slots/all-of-day": {
+      "get": {
+        "operationId": "SlotsController_2024_09_04_getAllSlotsForDay",
+        "summary": "Get all available slots for all event types on a given day",
+        "description": "Aggregates available slots across all non-archived, non-hidden event types for the specified date.",
+        "parameters": [
+          {
+            "name": "cal-api-version",
+            "in": "header",
+            "description": "Must be set to 2024-09-04",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "2024-09-04"
+            }
+          },
+          {
+            "name": "date",
+            "required": true,
+            "in": "query",
+            "example": "2050-09-05",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "timeZone",
+            "required": false,
+            "in": "query",
+            "description": "Time zone for slot formatting. Defaults to UTC.",
+            "example": "Europe/London",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "format",
+            "required": false,
+            "in": "query",
+            "description": "Format of slot times in response. Use 'range' to get start and end times.",
+            "example": "range",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Slots"]
+      }
+    },
     "/v2/slots/reservations": {
       "post": {
         "operationId": "SlotsController_2024_09_04_reserveSlot",


### PR DESCRIPTION
## What does this PR do?

Adds a new aggregated availability endpoint to API v2.

- Introduces GET `/v2/slots/all-of-day` to aggregate available slots across event types for a specific date
- Filters to non-hidden individual event types (userId != null, teamId = null)
- Returns per-event-type ownership identifiers (`ownerUserId`, `ownerTeamId`) to attribute slots
- Swagger/OpenAPI annotations added; OpenAPI JSON updated
- Adjusts unit test setup by mocking `PrismaReadService`

- Fixes #N/A
- Fixes CAL-N/A

## Visual Demo (For contributors especially)

Recommended: attach a short screen recording of calling the new endpoint and the JSON response.

#### Video Demo (if applicable):

- Show curl request against a dev environment and response snapshot.
- Demonstrate that slots are aggregated across multiple event types for the given day.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the response before/after (N/A for new endpoint).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. (OpenAPI/Swagger updated; docs site N/A)
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. (Unit test setup adjusted; additional coverage can follow)

## How should this be tested?

Pre-reqs (local):
- Node 18 + Yarn (Corepack)
- Local Postgres and seeded DB (`yarn workspace @calcom/prisma db-reset`)
- API v2 running with required env
- Redis running locally
- An admin API key for Authorization

Start API v2 (no Docker):

```bash
export NODE_ENV=development
export API_URL=http://localhost
export API_PORT=4000
export WEB_APP_URL=http://localhost:3000

export DATABASE_URL="postgresql://postgres@localhost:5450/cal-saml"
export DATABASE_READ_URL="$DATABASE_URL"
export DATABASE_WRITE_URL="$DATABASE_URL"

export NEXTAUTH_SECRET=<same as root .env>
export CALENDSO_ENCRYPTION_KEY=<same as root .env>
export JWT_SECRET=$(openssl rand -base64 32)

export REDIS_URL=redis://localhost:6379
export LOG_LEVEL=trace
export CALCOM_LICENSE_KEY=dev
export API_KEY_PREFIX=cal_

yarn workspace @calcom/api-v2 dev:no-docker
```

Call the new endpoint (replace the token with a valid admin/api key):

```bash
curl -G "http://localhost:4000/v2/slots/all-of-day" \
  -H "cal-api-version: 2024-09-04" \
  -H "Authorization: Bearer <API_KEY>" \
  --data-urlencode "date=2025-10-03" \
  --data-urlencode "timeZone=Europe/London" \
  --data-urlencode "format=range"
```

Expected (happy path):
- HTTP 200 with an array of objects. Each object contains:
  - `eventTypeId`, `eventTypeSlug`
  - `ownerUserId` (or `null` if team-owned)
  - `ownerTeamId` (or `null` if user-owned)
  - `slotsByDate` with a single key equal to the requested date containing the list of slots for that date

Example item:

```json
{
  "eventTypeId": 1086,
  "eventTypeSlug": "30min-33",
  "ownerUserId": 42,
  "ownerTeamId": null,
  "slotsByDate": {
    "2025-10-03": [
      { "start": "2025-10-03T09:00:00.000+01:00", "end": "2025-10-03T09:30:00.000+01:00" }
    ]
  }
}
```

Notes:
- Endpoint requires header `cal-api-version: 2024-09-04`.
- Aggregation currently includes non-hidden individual event types only.
